### PR TITLE
Home, year-round development, testimonials, + other adjustments

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -5,7 +5,9 @@ import Template from './Template'; //this is only an example that is for referen
 import UBNav from './UBNav.js';
 import UBHero from './UBHero.js';
 import UBWhiteSection from './UBWhiteSection.js';
+import UBDevelopment from './UBDevelopment.js';
 import UBBenefits from './UBBenefits.js';
+import UBTestimonials from './UBTestimonials.js';
 import UBApply from './UBApply.js'
 
 import logo from './images/upward-bound-big-logo.png';
@@ -47,13 +49,11 @@ function App() {
       */}
       <UBWhiteSection id="about" text={sitetext.about} setSection={setSection}/>
       <UBBenefits id="benefits" text={sitetext.benefits} setSection={setSection}/>
-      <UBWhiteSection id="development" text={sitetext.development} setSection={setSection}/>
+      <UBDevelopment id="development" text={sitetext.development} setSection={setSection}/>
       <div className="redbg" id="expectations"> 
         {/* Expectations */}
-      </div> 
-      <div className="graybg" id="testimonials"> 
-        {/* Testimonials */}
       </div>
+      <UBTestimonials id="testimonials" text={sitetext.testimonials} setSection={setSection}/>
       <UBApply id="apply" text={sitetext.apply} setSection={setSection}/>
       <div className="redbg" id="contact"> 
         {/* Contact */}

--- a/src/EmbedSocial.js
+++ b/src/EmbedSocial.js
@@ -2,11 +2,11 @@ import { Helmet } from 'react-helmet';
 
 function Embed() {
     return (
-        <div style={{ position: 'relative', left: '0px', top: '0px', width: '100vw'}}>
+        <div style={{width: '100%'}}>
             <Helmet>
                 <script src="https://widget.taggbox.com/embed-lite.min.js" type="text/javascript"></script>
             </Helmet>
-            <div className="taggbox" style={{ position: 'relative', padding: '0px', width: '90%', height: '100%' }} data-widget-id="121039" data-tags="false" />
+            <div className="taggbox" style={{width: '100%'}} data-widget-id="121039" data-tags="false" />
         </div>
     );
 }

--- a/src/UBBenefits.js
+++ b/src/UBBenefits.js
@@ -8,6 +8,7 @@ const UBBenefits = props => {
       </div>
       <div id="benefitstext" className="sectionhalf">
         <h2>{props.text.header}</h2>
+        <p dangerouslySetInnerHTML={{__html: props.text.description}}></p>
         {props.text.types.map(type => (
           <div key={type.header} className="benefittype">
             <div className="typeicon">

--- a/src/UBDevelopment.js
+++ b/src/UBDevelopment.js
@@ -1,0 +1,27 @@
+import NewSectionRef from "./NewSectionRef"
+const UBDevelopment = props => {
+  const ref = NewSectionRef(props)
+  return (
+    <div ref={ref} id={props.id} className="whitesec">
+      <div className="whitetext sectionhalf">
+        <h2>{props.text.header}</h2>
+        {props.text.programs.map((program, i) => (
+            <div>
+                <h3 key={program.header}>{program.header}</h3>
+                <p key={program.header + i}>{
+                    Array.isArray(program.text) ? (
+                        <ul>
+                            {program.text.map(bullet => (<li>{bullet}</li>))}
+                        </ul>
+                    ) : program.text
+                }</p>
+            </div>
+        ))}
+      </div>
+      <div className="whiteimg sectionhalf">
+        <img src={props.text.image}/>
+      </div>
+    </div>
+  )
+}
+export default UBDevelopment

--- a/src/UBHero.js
+++ b/src/UBHero.js
@@ -2,13 +2,14 @@ import NewSectionRef from "./NewSectionRef"
 const UBHero = props => {
   const ref = NewSectionRef(props)
   return (
-    <div ref={ref} id={props.id} className="redsec">
+    <div ref={ref} id={props.id} style={{backgroundImage: `url(${props.text.image})`}}>
       <div id="heroimg">
-        <img src={props.text.image}/>
+        {/*<img src={props.text.image}/>*/}
       </div>
       <div id="herotext">
         <h1>{props.text.header}</h1>
         <p>{props.text.description}</p>
+        <a href={props.text.formlink}>{props.text.button}</a>
       </div>
     </div>
   )

--- a/src/UBLatest.js
+++ b/src/UBLatest.js
@@ -5,7 +5,7 @@ const Latest = props => {
     return (
         <div ref={ref} id={props.id} className="redsec">
             <div id="latesttext">
-            <h1>{props.text.header}</h1>
+            <h2>{props.text.header}</h2>
                 <Embed/>
             </div>
         </div>

--- a/src/UBTestimonials.js
+++ b/src/UBTestimonials.js
@@ -1,0 +1,17 @@
+import NewSectionRef from "./NewSectionRef"
+const UBTestimonials = props => {
+  const ref = NewSectionRef(props)
+  return (
+    <div ref={ref} id={props.id} className="whitesec">
+        <h2>{props.text.header}</h2>
+        <p>{props.text.description}</p>
+        {props.text.quotes.map((quote, i) => (
+            <div className="quote">
+                <img src={quote.image}/>
+                <p>{quote.text}</p>
+            </div>
+        ))}
+    </div>
+  )
+}
+export default UBTestimonials

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -183,6 +183,9 @@ h3 {
     margin-top: 0;
     margin-bottom: 0
 }
+#latesttext {
+    width: 100%;
+}
 #testimonials {
     flex-direction: column;
     padding-left: 25%;

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -42,6 +42,7 @@ body {
     top: 0;
     color: white;
     transition: 0.5s all;
+    z-index: 1;
 }
 #nav.scrolled {
     background: white;
@@ -83,10 +84,24 @@ body {
     color: var(--UBRed);
 }
 #home {
-    background: var(--UBRedGradient);
-    background-blend-mode: hard-light, normal;
     height: 100vh;
     font-family: var(--herofont);
+    background-size: cover;
+    background-position-x: center;
+    background-position-y: top;
+    color: white;
+    display: flex;
+    padding: 100px;
+    align-items: center;
+}
+#home::before {
+    width: 100%;
+    height: 100vh;
+    background: black;
+    content: "";
+    position: absolute;
+    left: 0;
+    opacity: .5;
 }
 #heroimg {
     width: 50%;
@@ -94,6 +109,7 @@ body {
 }
 #herotext {
     width: 50%;
+    position: relative;
 }
 #herotext h1 {
     font-size: 50px;
@@ -103,7 +119,24 @@ body {
 }
 #herotext p {
     font-size: 20px;
-    line-height: 1.75
+    line-height: 1.75;
+    margin-bottom: 50px;
+}
+#herotext a {
+    font-weight: bold;
+    color: white;
+    outline: none;
+    border: 2px solid white;
+    font-size: 24px;
+    padding: 8px 48px;
+    border-radius: 10px;
+    text-decoration: none;
+    transition: 0.5s all;
+    cursor: pointer;
+}
+#herotext a:hover {
+    background: white;
+    color: black
 }
 .whitesec {
     display: flex;
@@ -111,7 +144,7 @@ body {
     padding: 100px;
     background: var(--UBWhite);
 }
-.whitesec h2 {
+.whitesec h2, .whitesec h3 {
     color: var(--UBRed);
 }
 .whitetext p {
@@ -124,6 +157,9 @@ h2 {
     font-weight: bold;
     font-size: 40px;
     margin-top: 0px;
+}
+#benefits {
+    line-height: 1.75
 }
 #benefitsimg {
     text-align: center;
@@ -140,12 +176,39 @@ h2 {
 }
 .typetext ul {
     padding: 0;
-    margin: 0.75em;
+    margin: 0;
 }
 h3 {
     font-size: 30px;
     margin-top: 0;
     margin-bottom: 0
+}
+#testimonials {
+    flex-direction: column;
+    padding-left: 25%;
+    padding-right: 25%;
+}
+#testimonials {
+    line-height: 1.75;
+}
+.quote {
+    width: 75%;
+    border: 3px solid var(--UBRed);
+    border-radius: 10px;
+    margin-top: 30px;
+    min-height: 175px;
+    padding: 20px 85px;
+    display: flex;
+    line-height: 1.5;
+    align-items: center;
+    position: relative;
+}
+.quote img {
+    height: 130px;
+    border-radius: 50%;
+    border: 3px solid var(--UBRed);
+    position: absolute;
+    left: -65px;
 }
 #apply {
     padding: 25px;
@@ -165,6 +228,7 @@ h3 {
     margin-bottom: 25px;
     width: 33.33%;
     display: inline-block;
+    line-height: 1.75;
 }
 #applybox a {
     background: var(--UBRed);
@@ -178,6 +242,7 @@ h3 {
     display: inline-block;
     text-decoration: none;
     transition: 0.5s all;
+    cursor: pointer;
 }
 #applybox a:hover {
     background: #c9243f

--- a/src/text/sitetext.json
+++ b/src/text/sitetext.json
@@ -4,7 +4,7 @@
         "about": "About",
         "benefits": "Benefits",
         "development": "Development",
-        "expectations": "Expectations",
+        "latest": "Events",
         "testimonials": "Testimonials",
         "apply": "Apply"
     },

--- a/src/text/sitetext.json
+++ b/src/text/sitetext.json
@@ -10,43 +10,49 @@
     },
     "home": {
         "header": "Enrich your learning with Upward Bound!",
-        "image": "student1.png",
-        "description": "Upward Bound program is a year-round, federally sponsored, educational program serving high school students from Springfield's High School of Commerce."
+        "image": "ubsplash.gif",
+        "description": "Upward Bound program is a year-round, federally sponsored, educational program serving high school students from Springfield's High School of Commerce.",
+        "button": "Apply Now",
+        "formlink": "#"
     },
     "about": {
         "header": "About",
         "image": "placeholder.png",
-        "description": "Upward Bound stresses the development of academic skills and internal motivation for students who might not traditionally be considered college-bound. During the academic year, participants are provided a variety of services ranging from individual tutoring, career advising, and SAT and MCAS prep to college-positive workshops, cultural enrichment, and much more. In addition, the program addresses other issues critical to success in high school and college such as time management, self-discipline, responsibility, self esteem, multicultural knowledge, social justice, and respect.\nStudents are eligible to participate if they are from families in which neither parent has a bachelor’s degree and/or if they qualify as low -income. Upward Bound’s goal is to increase the rate at which participants successfully complete high school and enroll in and graduate from college."
+        "description": "The UMass Amherst Upward Bound program is a year-long college preparatory program for first-generation and/or low-income high school students from Springfield, MA. We are committed to providing our students with opportunities to access higher education. In doing so, we recognize and work to confront barriers students face due to issues of race, class, gender, sexual orientation, ability, and more.\nUpward Bound is an intentionally inclusive program that celebrates diversity and the cultural and personal strengths each participant brings with them. We work together with youth to meet their academic and personal goals.\nWe provide customized individual attention and work with you toward your goals. Upward Bound’s central aim is to support each and every student in developing a college-going identity and successfully apply to, achieve admission to, and graduate from their college of choice. We provide academic, informational, and motivational support to participants as they prepare for — and embark on — this journey."
     },
     "benefits": {
         "header": "Benefits",
         "image": "placeholder.png",
+        "description": "Students receive a small stipend for attending Upward Bound programming, but <b>all programming itself (classes, meals, on-campus housing, and transportation) is free</b>",
         "types": [
             {
-                "header": "Personal",
+                "header": "In your academics",
                 "icon": "placeholder.png",
                 "bullets": [
-                    "Strengthened ability to read, write, and communicate.",
-                    "Expanded vocabulary and improved word usage.",
-                    "Improved analytical, reflective, and critical thinking skills.",
-                    "Preparation for the rigor of college academics by enrolling and succeeding in higher-level courses.",
-                    "Development of the skills and qualities that contribute to positive personal growth and development."
+                    "Strengthen your ability to read, write, and communicate.",
+                    "Expand your verbal understanding in class (vocabulary and concepts)",
+                    "Strengthen math skills, fluency and build your math mind-set.",
+                    "Improve your analytical, reflective, and critical thinking skills.",
+                    "Get assistance breaking down and completing difficult assignments",
+                    "Prepare for the rigor of college academics by enrolling and succeeding in higher-level courses (Honors, AP, and dual enrollment)"
                 ]
             },
             {
-                "header": "Community",
+                "header": "In your community",
                 "icon": "placeholder.png",
                 "bullets": [
-                    "Expanded worldview.",
-                    "Contributions through community service to build understanding of social justice."
+                    "Expand your worldview within and beyond Springfield",
+                    "Contribute through community service",
+                    "Build understanding of yourself, your core identities (who you are) and how you want to contribute to your home, community and the wider world around you."
                 ]
             },
             {
-                "header": "Future",
+                "header": "For your future",
                 "icon": "placeholder.png",
                 "bullets": [
-                    "Being prepared to make informed and appropriate choices regarding higher education.",
-                    "Development of a life-long love for learning and the skills needed to accomplish any goal."
+                    "Become prepared to make informed and appropriate choices regarding your choices for higher education.",
+                    "Develop the skills and qualities that contribute to positive personal growth and development (tools for wellbeing, healthy relationships, values clarification, stress management).",
+                    "Cultivate a life-long love for learning and the skills needed to accomplish any goal."
                 ]
             }
         ]
@@ -54,11 +60,60 @@
     "development": {
         "header": "Year-round Development",
         "image": "placeholder.png",
+        "programs": [
+            {
+                "header": "School-Year Programming",
+                "text": "During the school year, we offer tutoring and mentoring sessions to help with your classes, Saturday workshops, college visits, and cultural events. Along with academic preparation, the program’s focus is also on the development of critical thinking skills, successful study habits, time management, SAT and MCAS examination preparation, and personal development with an emphasis on each participant’s individual, academic, familial, and cultural strengths."
+            },
+            {
+                "header": "Saturday Programming",
+                "text": [
+                    "UMass Campus Experiences",
+                    "Humanities and Fine Arts Scholars Day (Foreign Language, Theater, Dance)",
+                    "Math, MCAS, and SAT Bootcamps",
+                    "Art Immersion with UMass Museums",
+                    "Public Health Day",
+                    "College and Scholarship Application Parties",
+                    "Seacoast Science Center (Beach) Trip",
+                    "College Visits to Boston, NYC, and Beyond"
+                ]
+            },
+            {
+                "header": "Summer Programming",
+                "text": "In the summer, Upward Bound holds a six-week residential Summer Institute with hands-on, engaging, college-like classes and holistic services based on students’ needs, all on the UMass Amherst campus. Students experience life on a college campus, take higher-level preparatory or credit-bearing courses, and enjoy fun, educational activities during the day."
+            }
+        ],
         "description": "Through a partnership with the University of Massachusetts Amherst, a Summer Institute supports students’ year-round development. The Institute takes place over six weeks during June, July, and/or August, providing students with the experience of living on a college campus, taking higher-level courses, and enjoying fun, educational activities during the day."
     },
+    "testimonials": {
+        "header": "Testimonials",
+        "description": "Here are some stories and words of appreciation from our program participants. Low-income and first-generation backgrounds have benefited greatly from the academic  and cultural enrichment activities provided by our program.",
+        "quotes": [
+            {
+                "image": "placeholder.png",
+                "text": "Upward Bound represents the embodiment of love. This is because of how we are treated and how we treat our peers."
+            },
+            {
+                "image": "placeholder.png",
+                "text": "Among my peers, we don't have successful family members or role models to look up to, but Upward Bound allows us to have adults to look up to, adults who truly believe in us."
+            },
+            {
+                "image": "placeholder.png",
+                "text": "The atmosphere allows me to feel confident in my abilities as a scholar, but also as a person."
+            },
+            {
+                "image": "placeholder.png",
+                "text": "It encourages a healthy environment where I can grow, and unequivocally be myself."
+            },
+            {
+                "image": "placeholder.png",
+                "text": "Upward Bound pushes me to be the best I can be."
+            }
+        ]
+    },
     "apply": {
-        "header": "Apply now!",
-        "description": "Ready to take the next step towards your college dreams? Apply now for our Upward Bound program and get the support you need to succeed in high school and beyond!",
+        "header": "Who can apply?",
+        "description": "Students are eligible to participate if the guardian they live with has not completed a bachelor’s degree and/or if they qualify as low-income.",
         "button": "Sign Up",
         "formlink": "#"
     }


### PR DESCRIPTION
# Home
I added the background gif, dimmed it a little, and removed the original image on the left. I added the apply now button directly below the home text (rather than on the bottom right corner) because I felt like it looked better there. It's also more likely to be noticed when placed there.

# Testimonials
I added the text and quotes for the testimonials section but I didn't add the background circles yet. I think we should get some sort of background image to replicate that.

# Other
I updated the text accordingly for all the other sections, including adding the programs to the year-round development section.

I adjusted the Insta widget on the latest section to take up 100% of the width more cleanly. I also switched the h1 to h2 in the section for better consistency. Finally, I modified the sitetext for the navbar to make the nav link bolding work for the latest section.